### PR TITLE
Fixed compiler warnings and link errors.

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -1,5 +1,7 @@
 include(GNUInstallDirs)
 
+add_compile_options(-Wall)
+
 # Specific compile optios across all targets
 #add_compile_definitions(MINIMAL_LOGGING)
 

--- a/src/tiovx_ldc_module.c
+++ b/src/tiovx_ldc_module.c
@@ -128,8 +128,6 @@ static vx_status tiovx_ldc_module_configure_mesh_params(vx_context context, TIOV
 {
     vx_status status = VX_SUCCESS;
 
-    SensorObj *sensorObj = obj->sensorObj;
-
     vx_uint32 table_width_ds, table_height_ds;
     vx_imagepatch_addressing_t image_addr;
     vx_rectangle_t rect;
@@ -207,8 +205,6 @@ static vx_status tiovx_ldc_module_configure_mesh_params(vx_context context, TIOV
 static vx_status tiovx_ldc_module_configure_region_params(vx_context context, TIOVXLDCModuleObj *obj)
 {
     vx_status status = VX_SUCCESS;
-
-    SensorObj *sensorObj = obj->sensorObj;
 
     /* Block Size parameters */
     obj->region_params.out_block_width  = LDC_BLOCK_WIDTH;

--- a/src/tiovx_sensor_module.c
+++ b/src/tiovx_sensor_module.c
@@ -62,8 +62,6 @@
 
 #include "tiovx_sensor_module.h"
 
-static char availableSensorNames[ISS_SENSORS_MAX_SUPPORTED_SENSOR][ISS_SENSORS_MAX_NAME];
-
 vx_status tiovx_querry_sensor(SensorObj *sensorObj)
 {
     vx_status status = VX_SUCCESS;

--- a/src/tiovx_viss_module.c
+++ b/src/tiovx_viss_module.c
@@ -191,7 +191,6 @@ static vx_status tiovx_viss_module_configure_dcc_params(vx_context context, TIOV
 static vx_status tiovx_viss_module_create_inputs(vx_context context, TIOVXVISSModuleObj *obj)
 {
     vx_status status = VX_SUCCESS;
-    vx_uint32 img_height, img_width;
     vx_int32 buf;
 
     SensorObj *sensorObj = obj->sensorObj;
@@ -277,7 +276,6 @@ static vx_status tiovx_viss_module_create_inputs(vx_context context, TIOVXVISSMo
 static vx_status tiovx_viss_module_create_outputs(vx_context context, TIOVXVISSModuleObj *obj)
 {
     vx_status status = VX_SUCCESS;
-    vx_uint32 img_height, img_width;
     vx_int32 buf;
 
     SensorObj *sensorObj = obj->sensorObj;

--- a/test/app_common.c
+++ b/test/app_common.c
@@ -1620,7 +1620,6 @@ vx_status create_tensor_mask(vx_tensor tensor_o, vx_int32 num_classes)
     vx_size start[APP_MAX_TENSOR_DIMS];
     vx_size tensor_strides[APP_MAX_TENSOR_DIMS];
     vx_size tensor_sizes[APP_MAX_TENSOR_DIMS];
-    vx_char new_name[APP_MAX_FILE_PATH];
     vx_enum data_type;
 
     vxQueryTensor(tensor_o, VX_TENSOR_NUMBER_OF_DIMS, &num_dims, sizeof(vx_size));
@@ -1671,8 +1670,6 @@ vx_status create_tensor_mask(vx_tensor tensor_o, vx_int32 num_classes)
 vx_status allocate_single_user_data_buffer(vx_user_data_object user_data, void *virtAddr[], vx_uint32 sizes[])
 {
     vx_status status = VX_SUCCESS;
-
-    void      *buf_addr[TIOVX_MODULES_MAX_REF_HANDLES] = {NULL};
 
     vx_size data_size;
 
@@ -2212,7 +2209,7 @@ vx_status delete_single_pyramid_buffer(vx_pyramid pyramid, void *virtAddr[], vx_
 
     if((vx_status)VX_SUCCESS == status)
     {
-        vx_int32 p, l;
+        vx_int32 l;
         void      *plane_addr[TIOVX_MODULES_MAX_REF_HANDLES] = {NULL};
         vx_uint32  plane_sizes[TIOVX_MODULES_MAX_REF_HANDLES];
         vx_size   num_levels;

--- a/test/app_tiovx_color_convert_module_test.c
+++ b/test/app_tiovx_color_convert_module_test.c
@@ -80,7 +80,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);
@@ -229,8 +229,6 @@ static vx_status app_verify_graph(AppObj *obj)
 
     return status;
 }
-
-static vx_status writeOutput(char* file_name, vx_image out_img);
 
 static vx_status app_run_graph(AppObj *obj)
 {

--- a/test/app_tiovx_dl_color_blend_module_test.c
+++ b/test/app_tiovx_dl_color_blend_module_test.c
@@ -84,7 +84,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);

--- a/test/app_tiovx_dl_color_convert_module_test.c
+++ b/test/app_tiovx_dl_color_convert_module_test.c
@@ -80,7 +80,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);
@@ -237,8 +237,6 @@ static vx_status app_verify_graph(AppObj *obj)
 
     return status;
 }
-
-static vx_status writeOutput(char* file_name, vx_image out_img);
 
 static vx_status app_run_graph(AppObj *obj)
 {

--- a/test/app_tiovx_dl_pre_proc_module_test.c
+++ b/test/app_tiovx_dl_pre_proc_module_test.c
@@ -80,7 +80,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);

--- a/test/app_tiovx_dof_module_test.c
+++ b/test/app_tiovx_dof_module_test.c
@@ -82,7 +82,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);

--- a/test/app_tiovx_dof_viz_module_test.c
+++ b/test/app_tiovx_dof_viz_module_test.c
@@ -80,7 +80,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);

--- a/test/app_tiovx_img_mosaic_module_test.c
+++ b/test/app_tiovx_img_mosaic_module_test.c
@@ -81,7 +81,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);

--- a/test/app_tiovx_ldc_module_test.c
+++ b/test/app_tiovx_ldc_module_test.c
@@ -85,7 +85,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);

--- a/test/app_tiovx_multi_scaler_module_test.c
+++ b/test/app_tiovx_multi_scaler_module_test.c
@@ -81,7 +81,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);

--- a/test/app_tiovx_pyramid_module_test.c
+++ b/test/app_tiovx_pyramid_module_test.c
@@ -82,7 +82,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);

--- a/test/app_tiovx_viss_module_test.c
+++ b/test/app_tiovx_viss_module_test.c
@@ -94,7 +94,7 @@ typedef struct {
 
 } AppObj;
 
-AppObj gAppObj;
+static AppObj gAppObj;
 
 static vx_status app_init(AppObj *obj);
 static void app_deinit(AppObj *obj);


### PR DESCRIPTION
Each test code file defines 'gAppObj' at the file scope and does not
specify it to be static. This causes link errors when multiple of these
tests are enabled.