### PR TITLE
test: viss: am62a: Define out0Addr and out0Sizes only for AM62A

### DIFF
--- a/test/app_tiovx_viss_module_test.c
+++ b/test/app_tiovx_viss_module_test.c
@@ -471,13 +471,17 @@ static vx_status app_run_graph(AppObj *obj)
     int32_t frame_count;
 
     void *inAddr[APP_BUFQ_DEPTH][TIOVX_MODULES_MAX_REF_HANDLES] = {NULL};
+#if defined(SOC_AM62A)
     void *out0Addr[APP_BUFQ_DEPTH][TIOVX_MODULES_MAX_REF_HANDLES] = {NULL};
+#endif
     void *out2Addr[APP_BUFQ_DEPTH][TIOVX_MODULES_MAX_REF_HANDLES] = {NULL};
     void *aewbAddr[APP_BUFQ_DEPTH][TIOVX_MODULES_MAX_REF_HANDLES] = {NULL};
     void *h3aAddr[APP_BUFQ_DEPTH][TIOVX_MODULES_MAX_REF_HANDLES] = {NULL};
 
     vx_uint32 inSizes[APP_BUFQ_DEPTH][TIOVX_MODULES_MAX_REF_HANDLES];
+#if defined(SOC_AM62A)
     vx_uint32 out0Sizes[APP_BUFQ_DEPTH][TIOVX_MODULES_MAX_REF_HANDLES];
+#endif
     vx_uint32 out2Sizes[APP_BUFQ_DEPTH][TIOVX_MODULES_MAX_REF_HANDLES];
     vx_uint32 aewbSizes[APP_BUFQ_DEPTH][TIOVX_MODULES_MAX_REF_HANDLES];
     vx_uint32 h3aSizes[APP_BUFQ_DEPTH][TIOVX_MODULES_MAX_REF_HANDLES];


### PR DESCRIPTION
As these were generating warnings for J7 family of SOCs

Signed-off-by: Shubham Jain <a0492788@ti.com>