### PR TITLE
test: main: Fix the #defines used for SOC

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -73,7 +73,7 @@
 #define APP_MODULES_TEST_VISS (1)
 #define APP_MODULES_TEST_PYRAMID (1)
 
-#if defined(J721E) || defined(J721S2)
+#if defined(SOC_J721E) || defined(SOC_J721S2)
 #define APP_MODULES_TEST_COLOR_CONVERT (1)
 #define APP_MODULES_TEST_DL_PRE_PROC (1)
 #define APP_MODULES_TEST_DL_COLOR_BLEND (1)


### PR DESCRIPTION
Fix the #defines used for checking the
Target SOC

Signed-off-by: Rahul T R <r-ravikumar@ti.com>