### PR TITLE
Include edgeai-tiovx-nodes as dependency for some C66 openVX nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,15 +13,15 @@ set(SRC_FILES
     src/tiovx_viss_module.c
     src/tiovx_ldc_module.c
     src/tiovx_pyramid_module.c
+    src/tiovx_dl_color_convert_module.c
+    src/tiovx_dl_pre_proc_module.c
+    src/tiovx_dl_color_blend_module.c
     src/tiovx_utils.c)
 
 if ("${TARGET_SOC}" STREQUAL "J721E" OR "${TARGET_SOC}" STREQUAL "J721S2" OR "${TARGET_SOC}" STREQUAL "J784S4")
     list(APPEND
          SRC_FILES
          src/tiovx_color_convert_module.c
-         src/tiovx_dl_color_convert_module.c
-         src/tiovx_dl_pre_proc_module.c
-         src/tiovx_dl_color_blend_module.c
          src/tiovx_dof_module.c
          src/tiovx_dof_viz_module.c
          src/tiovx_sde_module.c

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -93,10 +93,12 @@ include_directories(${PROJECT_SOURCE_DIR}
                     ${TARGET_FS}/usr/include/processor_sdk/vision_apps/kernels/img_proc/include
                     ${TARGET_FS}/usr/include/processor_sdk/vision_apps/kernels/fileio/include
                     ${TARGET_FS}/usr/include/processor_sdk/vision_apps/kernels/stereo/include
+                    ${TARGET_FS}/usr/include/processor_sdk/edgeai-tiovx-kernels/include
                    )
 
 set(SYSTEM_LINK_LIBS
     tivision_apps
+    tiedgeai_tiovx_kernels
     )
 
 set(COMMON_LINK_LIBS

--- a/include/tiovx_modules_common.h
+++ b/include/tiovx_modules_common.h
@@ -66,6 +66,7 @@
 #include <TI/tivx_task.h>
 #include <TI/tivx_target_kernel.h>
 #include <TI/tivx_img_proc.h>
+#include <edgeai_tiovx_target_kernels.h>
 
 #include <TI/j7_tidl.h>
 #include <TI/tivx_fileio.h>

--- a/test/app_tiovx_dl_color_convert_module_test.c
+++ b/test/app_tiovx_dl_color_convert_module_test.c
@@ -133,6 +133,7 @@ static vx_status app_init(AppObj *obj)
     if(status == VX_SUCCESS)
     {
         tivxImgProcLoadKernels(obj->context);
+        tivxEdgeaiImgProcLoadKernels(obj->context);
     }
 
     if(status == VX_SUCCESS)
@@ -164,6 +165,7 @@ static void app_deinit(AppObj *obj)
     tiovx_dl_color_convert_module_deinit(&obj->colorConvertObj);
 
     tivxImgProcUnLoadKernels(obj->context);
+    tivxEdgeaiImgProcUnLoadKernels(obj->context);
 
     vxReleaseContext(&obj->context);
 }


### PR DESCRIPTION
For now four of C66 openVX nodes will be part of edgeai-tiovx-nodes
    -> dl_color_blend
    -> dl_color_convert
    -> dl_draw_box
    -> dl_pre_proc

Signed-off-by: Shubham Jain <a0492788@ti.com>