### PR TITLE
Add edgeai-tiovx-kernels as dependency and remove DSP target in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,15 +13,15 @@ set(SRC_FILES
     src/tiovx_viss_module.c
     src/tiovx_ldc_module.c
     src/tiovx_pyramid_module.c
+    src/tiovx_dl_color_convert_module.c
+    src/tiovx_dl_pre_proc_module.c
+    src/tiovx_dl_color_blend_module.c
     src/tiovx_utils.c)
 
 if ("${TARGET_SOC}" STREQUAL "J721E" OR "${TARGET_SOC}" STREQUAL "J721S2" OR "${TARGET_SOC}" STREQUAL "J784S4")
     list(APPEND
          SRC_FILES
          src/tiovx_color_convert_module.c
-         src/tiovx_dl_color_convert_module.c
-         src/tiovx_dl_pre_proc_module.c
-         src/tiovx_dl_color_blend_module.c
          src/tiovx_dof_module.c
          src/tiovx_dof_viz_module.c
          src/tiovx_sde_module.c

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -93,10 +93,12 @@ include_directories(${PROJECT_SOURCE_DIR}
                     ${TARGET_FS}/usr/include/processor_sdk/vision_apps/kernels/img_proc/include
                     ${TARGET_FS}/usr/include/processor_sdk/vision_apps/kernels/fileio/include
                     ${TARGET_FS}/usr/include/processor_sdk/vision_apps/kernels/stereo/include
+                    ${TARGET_FS}/usr/include/edgeai-tiovx-kernels
                    )
 
 set(SYSTEM_LINK_LIBS
     tivision_apps
+    edgeai-tiovx-kernels
     )
 
 set(COMMON_LINK_LIBS

--- a/include/tiovx_dl_color_blend_module.h
+++ b/include/tiovx_dl_color_blend_module.h
@@ -73,7 +73,7 @@ typedef struct {
     vx_kernel kernel;
 
     vx_user_data_object config;
-    tivxDLColorBlendParams params;
+    tivxDLColorBlendArmv8Params params;
 
     ImgObj img_input;
     TensorObj tensor_input;

--- a/include/tiovx_dl_pre_proc_module.h
+++ b/include/tiovx_dl_pre_proc_module.h
@@ -71,7 +71,7 @@ extern "C" {
 typedef struct {
     vx_node node;
     vx_user_data_object config;
-    tivxDLPreProcParams params;
+    tivxDLPreProcArmv8Params params;
 
     ImgObj input;
     TensorObj output;

--- a/include/tiovx_modules_common.h
+++ b/include/tiovx_modules_common.h
@@ -66,6 +66,7 @@
 #include <TI/tivx_task.h>
 #include <TI/tivx_target_kernel.h>
 #include <TI/tivx_img_proc.h>
+#include <edgeai_tiovx_img_proc.h>
 
 #include <TI/j7_tidl.h>
 #include <TI/tivx_fileio.h>

--- a/src/tiovx_dl_color_blend_module.c
+++ b/src/tiovx_dl_color_blend_module.c
@@ -65,20 +65,20 @@ static vx_status tiovx_dl_color_blend_module_create_config(vx_context context, T
 {
     vx_status status = VX_SUCCESS;
 
-    tivxDLColorBlendParams *params;
+    tivxDLColorBlendArmv8Params *params;
     vx_map_id map_id;
 
-    obj->config = vxCreateUserDataObject(context, "tivxDLColorBlendParams", sizeof(tivxDLColorBlendParams), NULL );
+    obj->config = vxCreateUserDataObject(context, "tivxDLColorBlendArmv8Params", sizeof(tivxDLColorBlendArmv8Params), NULL );
     status = vxGetStatus((vx_reference)obj->config);
 
     if (VX_SUCCESS == status)
     {
         vxSetReferenceName((vx_reference)obj->config, "dl_color_blend_config");
 
-        vxMapUserDataObject(obj->config, 0, sizeof(tivxDLColorBlendParams), &map_id,
+        vxMapUserDataObject(obj->config, 0, sizeof(tivxDLColorBlendArmv8Params), &map_id,
                         (void **)&params, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, 0);
 
-        memcpy(params, &obj->params, sizeof(tivxDLColorBlendParams));
+        memcpy(params, &obj->params, sizeof(tivxDLColorBlendArmv8Params));
 
         vxUnmapUserDataObject(obj->config, map_id);
     }
@@ -442,7 +442,7 @@ vx_status tiovx_dl_color_blend_module_create(vx_graph graph, TIOVXDLColorBlendMo
         img_output = NULL;
     }
 
-    obj->node = tivxDLColorBlendNode(graph, obj->config, img_input, tensor_input, img_output);
+    obj->node = tivxDLColorBlendArmv8Node(graph, obj->config, img_input, tensor_input, img_output);
     status = vxGetStatus((vx_reference)obj->node);
 
     if((vx_status)VX_SUCCESS == status)

--- a/src/tiovx_dl_color_convert_module.c
+++ b/src/tiovx_dl_color_convert_module.c
@@ -324,7 +324,7 @@ vx_status tiovx_dl_color_convert_module_create(vx_graph graph, TIOVXDLColorConve
         output = NULL;
     }
 
-    obj->node = tivxDLColorConvertNode(graph, input, output);
+    obj->node = tivxDLColorConvertArmv8Node(graph, input, output);
     status = vxGetStatus((vx_reference)obj->node);
 
     if((vx_status)VX_SUCCESS == status)

--- a/src/tiovx_dl_pre_proc_module.c
+++ b/src/tiovx_dl_pre_proc_module.c
@@ -68,7 +68,7 @@ static vx_status tiovx_dl_pre_proc_module_create_config(vx_context context, TIOV
     tivxDLPreProcParams *params;
     vx_map_id map_id;
 
-    obj->config = vxCreateUserDataObject(context, "tivxDLPreProcParams", sizeof(tivxDLPreProcParams), NULL );
+    obj->config = vxCreateUserDataObject(context, "tivxDLPreProcArmv8Params", sizeof(tivxDLPreProcArmv8Params), NULL );
     status = vxGetStatus((vx_reference)obj->config);
 
     if (VX_SUCCESS == status)
@@ -78,7 +78,7 @@ static vx_status tiovx_dl_pre_proc_module_create_config(vx_context context, TIOV
         vxMapUserDataObject(obj->config, 0, sizeof(tivxDLPreProcParams), &map_id,
                         (void **)&params, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST, 0);
 
-        memcpy(params, &obj->params, sizeof(tivxDLPreProcParams));
+        memcpy(params, &obj->params, sizeof(tivxDLPreProcArmv8Params));
 
         vxUnmapUserDataObject(obj->config, map_id);
     }
@@ -361,7 +361,7 @@ vx_status tiovx_dl_pre_proc_module_create(vx_graph graph, TIOVXDLPreProcModuleOb
         output = NULL;
     }
 
-    obj->node = tivxDLPreProcNode(graph, obj->config, input, output);
+    obj->node = tivxDLPreProcArmv8Node(graph, obj->config, input, output);
     status = vxGetStatus((vx_reference)obj->node);
 
     if((vx_status)VX_SUCCESS == status)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,15 +10,15 @@ set(SRC_FILES
     app_tiovx_viss_module_test.c
     app_tiovx_ldc_module_test.c
     app_tiovx_pyramid_module_test.c
+    app_tiovx_dl_color_convert_module_test.c
+    app_tiovx_dl_pre_proc_module_test.c
+    app_tiovx_dl_color_blend_module_test.c
     main.c)
 
 if ("${TARGET_SOC}" STREQUAL "J721E" OR "${TARGET_SOC}" STREQUAL "J721S2" OR "${TARGET_SOC}" STREQUAL "J784S4")
     list(APPEND
          SRC_FILES
          app_tiovx_color_convert_module_test.c
-         app_tiovx_dl_color_convert_module_test.c
-         app_tiovx_dl_pre_proc_module_test.c
-         app_tiovx_dl_color_blend_module_test.c
          app_tiovx_dof_module_test.c
          app_tiovx_dof_viz_module_test.c
          app_tiovx_sde_module_test.c

--- a/test/app_tiovx_dl_color_blend_module_test.c
+++ b/test/app_tiovx_dl_color_blend_module_test.c
@@ -137,6 +137,7 @@ static vx_status app_init(AppObj *obj)
     {
         tivxHwaLoadKernels(obj->context);
         tivxImgProcLoadKernels(obj->context);
+        tivxEdgeaiImgProcLoadKernels(obj->context);
     }
 
     if(status == VX_SUCCESS)
@@ -178,6 +179,8 @@ static void app_deinit(AppObj *obj)
 {
     tiovx_dl_color_blend_module_deinit(&obj->dlColorBlendObj);
 
+    tivxEdgeaiImgProcUnLoadKernels(obj->context);
+
     tivxImgProcUnLoadKernels(obj->context);
 
     tivxHwaUnLoadKernels(obj->context);
@@ -204,7 +207,7 @@ static vx_status app_create_graph(AppObj *obj)
 
     if((vx_status)VX_SUCCESS == status)
     {
-        status = tiovx_dl_color_blend_module_create(obj->graph, &obj->dlColorBlendObj, NULL, NULL, TIVX_TARGET_DSP1);
+        status = tiovx_dl_color_blend_module_create(obj->graph, &obj->dlColorBlendObj, NULL, NULL, TIVX_TARGET_A72_0);
     }
 
     graph_parameter_index = 0;

--- a/test/app_tiovx_dl_color_convert_module_test.c
+++ b/test/app_tiovx_dl_color_convert_module_test.c
@@ -133,6 +133,7 @@ static vx_status app_init(AppObj *obj)
     if(status == VX_SUCCESS)
     {
         tivxImgProcLoadKernels(obj->context);
+        tivxEdgeaiImgProcLoadKernels(obj->context);
     }
 
     if(status == VX_SUCCESS)
@@ -164,6 +165,7 @@ static void app_deinit(AppObj *obj)
     tiovx_dl_color_convert_module_deinit(&obj->colorConvertObj);
 
     tivxImgProcUnLoadKernels(obj->context);
+    tivxEdgeaiImgProcUnLoadKernels(obj->context);
 
     vxReleaseContext(&obj->context);
 }
@@ -187,7 +189,7 @@ static vx_status app_create_graph(AppObj *obj)
 
     if((vx_status)VX_SUCCESS == status)
     {
-        status = tiovx_dl_color_convert_module_create(obj->graph, &obj->colorConvertObj, NULL, TIVX_TARGET_DSP1);
+        status = tiovx_dl_color_convert_module_create(obj->graph, &obj->colorConvertObj, NULL, TIVX_TARGET_A72_0);
     }
 
     graph_parameter_index = 0;

--- a/test/app_tiovx_dl_pre_proc_module_test.c
+++ b/test/app_tiovx_dl_pre_proc_module_test.c
@@ -133,6 +133,7 @@ static vx_status app_init(AppObj *obj)
     {
         tivxHwaLoadKernels(obj->context);
         tivxImgProcLoadKernels(obj->context);
+        tivxEdgeaiImgProcLoadKernels(obj->context);
     }
 
     if(status == VX_SUCCESS)
@@ -184,6 +185,8 @@ static void app_deinit(AppObj *obj)
 {
     tiovx_dl_pre_proc_module_deinit(&obj->dlPreProcObj);
 
+    tivxEdgeaiImgProcUnLoadKernels(obj->context);
+
     tivxImgProcUnLoadKernels(obj->context);
 
     tivxHwaUnLoadKernels(obj->context);
@@ -210,7 +213,7 @@ static vx_status app_create_graph(AppObj *obj)
 
     if((vx_status)VX_SUCCESS == status)
     {
-        status = tiovx_dl_pre_proc_module_create(obj->graph, &obj->dlPreProcObj, NULL, TIVX_TARGET_DSP1);
+        status = tiovx_dl_pre_proc_module_create(obj->graph, &obj->dlPreProcObj, NULL, TIVX_TARGET_A72_0);
     }
 
     graph_parameter_index = 0;


### PR DESCRIPTION
This commit addresses following:
1) Adds link to libedgeai-tiovx-kernels.so for dl_pre_proc,
   dl_color_convert, dl_color_blend modules
2) Remove DSP target and add Armv8 target instead in tests

Signed-off-by: Shubham Jain <a0492788@ti.com>