### PR TITLE
Enable DCC live tuning by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ build_lib(${PROJECT_NAME}  # Named argument: library name
 add_subdirectory(test)
 
 option(INSTALL_SRC      "Install src under /opt" OFF)
-option(ENABLE_DCC_TOOL  "Enable DCC Tuning Tool Support" OFF)
+option(ENABLE_DCC_TOOL  "Enable DCC Tuning Tool Support" ON)
 
 if (INSTALL_SRC)
     install(DIRECTORY   ${CMAKE_CURRENT_SOURCE_DIR}/


### PR DESCRIPTION
This will enable DCC live tuning by default so that users won't have to rebuild tiovx-modules to do live tuning.